### PR TITLE
get node shebang from env

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 var imdb = require('imdb-api');
 var Table = require('cli-table');


### PR DESCRIPTION
`imdb-cli` command was not working due to that I'm using [nvm](https://github.com/creationix/nvm) like most of the people. It couldn't find `node` path.

So, I've updated it to get `node` path from shebang automatically.